### PR TITLE
Bump MSTest.TestAdapter and MSTest.TestFramework from 1.4.0 to 2.0.0

### DIFF
--- a/AlexaLambdaHandler.Tests/AlexaLambdaHandler.Tests.csproj
+++ b/AlexaLambdaHandler.Tests/AlexaLambdaHandler.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Alexa.NET" Version="1.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Supersedes #6 and #9